### PR TITLE
Sms command name fix

### DIFF
--- a/src/config/database.js
+++ b/src/config/database.js
@@ -2,7 +2,7 @@ require("env2")(".env");
 const Sequelize = require("sequelize");
 
 class Database {
-  
+
   constructor() {
     if (Database._instance) {
       throw new Error(
@@ -24,17 +24,18 @@ class Database {
 
     try {
       this.sequelize.authenticate();
-      console.log("Database connection has been established successfully.");
+      console.log("Database onnection has been established successfully.");
     } catch (error) {
       console.error("Unable to connect to the database:", error);
     }
+}
 
-    Database._instance = this;
+static getInstance() {
+  if (!this._instance){
+    this._instance = new Database();
   }
-
-  static getInstance() {
-    return Database._instance;
-  }
+  return this._instance;
+}
 
   parseSSLEnvVar() {
     this.sequelize_ssl = process.env.SEQUELIZE_SSL.toLowerCase();

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -24,7 +24,7 @@ class Database {
 
     try {
       this.sequelize.authenticate();
-      console.log("Database onnection has been established successfully.");
+      console.log("Database connection has been established successfully.");
     } catch (error) {
       console.error("Unable to connect to the database:", error);
     }

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -399,6 +399,7 @@ static getInstance() {
           type: this.sequelize.QueryTypes.INSERT,
         }
       );
+      console.log({result});
       return result;
     }
     catch(err){

--- a/src/lib/sms.js
+++ b/src/lib/sms.js
@@ -416,7 +416,7 @@ class Sms {
   parameterCountMatch(command, parameterObj) {
     if (
       parameterObj.commandArray.length == 1 &&
-      command.commandName == "manual"
+      command.name == "manual"
     ) {
       return true;
     } else {
@@ -436,7 +436,7 @@ class Sms {
       if (!this.parameterCountMatch(command, parameterObj)) {
         responseValue =
           "Incorrect syntax for '" +
-          command.commandName +
+          command.name +
           "':\n" +
           command.parameterUsage;
         return responseValue;


### PR DESCRIPTION
Fixes the `.commandName` -> `.name` issue that was breaking some SMS commands.

This branch is off of another as-of-yet-unmerged branch, `database-fix`, that implements the ES6 singleton in `database.js`.  I'm guessing that merging this one will automatically merge `database-fix` as well?

Regarding the ES6 singleton in `database.js`: you had expressed some concerns about a static method being able to access `this.`, but I've tested this and it works.