### PR TITLE
Admin contact info

### DIFF
--- a/src/command-config.json
+++ b/src/command-config.json
@@ -27,6 +27,13 @@
         "parameterCount":4,
         "adminTask":"addUser"
     },
+    "admincontactinfo":{
+        "name":"admincontactinfo",
+        "description":"Returns contact info for the system administrator.",
+        "parameterUsage":"admincontactinfo",
+        "parameterCount":1,
+        "adminTask":null
+    },
     "changename":{
         "name":"changename",
         "description":"Changes a user's name.",

--- a/src/lib/sms.js
+++ b/src/lib/sms.js
@@ -345,6 +345,11 @@ class Sms {
     return responseValue;
   }
 
+  async admincontactinfo(parameterObj){
+    return `Name: ${process.env.ADMIN_NAME}\n`+
+              `Phone: ${process.env.ADMIN_PHONE_NUMBER}`;
+  }
+
   async status(parameterObj) {
     var attributes = JSON.parse(parameterObj.workerEntity.attributes);
     var do_not_contact = attributes.do_not_contact;


### PR DESCRIPTION
In resolving issue #49, I realized that we don't currently have a way for users to get the administrator's contact info after it's provided to them in their initial welcome message.  I added an SMS command `admincontactinfo` that responds with a message including the admin's name and phone number.